### PR TITLE
fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e TZ=Etc/UTC` | specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List). |
 | `-e FG_LOG_LEVEL=info` | Set the FlexGet logging level. |
 | `-e FG_WEBUI_PASSWORD=info` | Set the FlexGet webui password. Pay attention to Bash/YAML reserved characters. |
-| `-v /config` | Local path for sabnzbd config files. |
+| `-v /config` | Local path for FlexGet config files. |
 | `-v /data` | Default path for downloads. |
 
 ## Environment variables from files (Docker secrets)

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -24,7 +24,7 @@ param_env_vars:
   - { env_var: "FG_LOG_LEVEL", env_value: "info", desc: "Set the FlexGet logging level." }
 param_usage_include_vols: true
 param_volumes:
-  - { vol_path: "/config", vol_host_path: "/path/to/data", desc: "Local path for sabnzbd config files." }
+  - { vol_path: "/config", vol_host_path: "/path/to/data", desc: "Local path for FlexGet config files." }
 param_usage_include_ports: true
 param_ports:
   - { external_port: "5050", internal_port: "5050", port_desc: "HTTP port for the WebUI." }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-flexget/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

in the parameter table, the config volume mount should be named flexget config not sabnzbd.

