### PR TITLE
add pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN \
   uv venv /lsiopy && \
   uv run scripts/bundle_webui.py && \
   uv sync --frozen --no-dev --no-cache --group=all && \
+  uv pip install pip && \
   printf "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" > /build_version && \
   echo "**** cleanup ****" && \
   apk del --purge \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -53,6 +53,7 @@ RUN \
   uv venv /lsiopy && \
   uv run scripts/bundle_webui.py && \
   uv sync --frozen --no-dev --no-cache --group=all && \
+  uv pip install pip && \
   printf "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" > /build_version && \
   echo "**** cleanup ****" && \
   apk del --purge \

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **17.10.25:** - Add pip to enable [universal-package-install mod](https://github.com/linuxserver/docker-mods/tree/universal-package-install).
 * **18.09.24:** - Suppress creation of empty log file when WebUI password is set.
 * **17.08.24:** - Revert to Alpine 3.20 due to 1st party plugin incompatibility with Python 3.12.
 * **19.06.24:** - Rebase to Alpine 3.20.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -92,6 +92,7 @@ init_diagram: |
   "flexget:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "17.10.25:", desc: "Add pip to enable [universal-package-install mod](https://github.com/linuxserver/docker-mods/tree/universal-package-install)."}
   - {date: "18.09.24:", desc: "Suppress creation of empty log file when WebUI password is set."}
   - {date: "17.08.24:", desc: "Revert to Alpine 3.20 due to 1st party plugin incompatibility with Python 3.12."}
   - {date: "19.06.24:", desc: "Rebase to Alpine 3.20."}


### PR DESCRIPTION
closes #25 

Apparently `uv venv /lsiopy` does not add `pip` to the venv so we have to install it manually.