### PR TITLE
Remove deprecated option --autoreload-config

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-flexget/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-flexget/run
@@ -4,4 +4,4 @@
 exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 5050" \
         cd /config s6-setuidgid abc python3 /lsiopy/bin/flexget \
-            --loglevel "${FG_LOG_LEVEL:-info}" --logfile "${FG_LOG_FILE:-/config/.flexget/flexget.log}" -c "${FG_CONFIG_FILE:-/config/.flexget/config.yml}" daemon start --autoreload-config
+            --loglevel "${FG_LOG_LEVEL:-info}" --logfile "${FG_LOG_FILE:-/config/.flexget/flexget.log}" -c "${FG_CONFIG_FILE:-/config/.flexget/config.yml}" daemon start


### PR DESCRIPTION
Hi,

`--autoreload-config` is deprecated since 3.19.0. See:

https://github.com/Flexget/Flexget/pull/4899
https://flexget.com/ChangeLog#h-3190-2026-03-05

It's currently still available for backwards compatibility but it should be in order to remove it now.